### PR TITLE
test(core,parser): close backlog test gaps and harden margin grid phy…

### DIFF
--- a/ketraterm-core/src/main/kotlin/io/github/ketraterm/core/engine/MutationEngine.kt
+++ b/ketraterm-core/src/main/kotlin/io/github/ketraterm/core/engine/MutationEngine.kt
@@ -236,10 +236,23 @@ internal class MutationEngine(
         left: Int,
         right: Int,
     ) {
+        // Clear potential orphaned spacer on dest
+        if (right + 1 < width && dest.rawCodepoint(right + 1) == TerminalConstants.WIDE_CHAR_SPACER) {
+            dest.setCell(right + 1, TerminalConstants.EMPTY, blankAttr, blankExtendedAttr)
+        }
+
         for (col in left..right) {
-            val raw = src.rawCodepoint(col)
-            val attr = src.getPackedAttr(col)
-            val extendedAttr = src.getPackedExtendedAttr(col)
+            var raw = src.rawCodepoint(col)
+            var attr = src.getPackedAttr(col)
+            var extendedAttr = src.getPackedExtendedAttr(col)
+
+            if (col == left && raw == TerminalConstants.WIDE_CHAR_SPACER) {
+                // Do not copy the spacer without its leader
+                raw = TerminalConstants.EMPTY
+                attr = blankAttr
+                extendedAttr = blankExtendedAttr
+            }
+
             if (raw <= TerminalConstants.CLUSTER_HANDLE_MAX) {
                 val cpLen = src.store.length(raw)
                 if (clusterScratch.size < cpLen) {
@@ -632,6 +645,9 @@ internal class MutationEngine(
                 }
                 for (row in topRow until topRow + times) {
                     val line = getLine(row)
+                    if (rightMargin + 1 < width && line.rawCodepoint(rightMargin + 1) == TerminalConstants.WIDE_CHAR_SPACER) {
+                        annihilateAt(row, rightMargin + 1)
+                    }
                     line.clearRange(leftMargin, rightMargin + 1, blankAttr, blankExtendedAttr)
                     line.wrapped = false
                     state.markLineChanged(line)
@@ -667,6 +683,9 @@ internal class MutationEngine(
                 }
                 for (row in bottomRow - times + 1..bottomRow) {
                     val line = getLine(row)
+                    if (rightMargin + 1 < width && line.rawCodepoint(rightMargin + 1) == TerminalConstants.WIDE_CHAR_SPACER) {
+                        annihilateAt(row, rightMargin + 1)
+                    }
                     line.clearRange(leftMargin, rightMargin + 1, blankAttr, blankExtendedAttr)
                     line.wrapped = false
                     state.markLineChanged(line)
@@ -710,6 +729,12 @@ internal class MutationEngine(
                 annihilateAt(cRow, edgeCol)
             }
 
+            if (rightMargin + 1 < width &&
+                line.rawCodepoint(rightMargin + 1) == TerminalConstants.WIDE_CHAR_SPACER
+            ) {
+                annihilateAt(cRow, rightMargin + 1)
+            }
+
             line.insertCellsInRange(cCol, safeCount, rightMargin, blankAttr, blankExtendedAttr)
             state.markLineChanged(line)
         }
@@ -738,6 +763,12 @@ internal class MutationEngine(
                 ) {
                     annihilateAt(cRow, rightEdge)
                 }
+            }
+
+            if (rightMargin + 1 < width &&
+                getLine(cRow).rawCodepoint(rightMargin + 1) == TerminalConstants.WIDE_CHAR_SPACER
+            ) {
+                annihilateAt(cRow, rightMargin + 1)
             }
 
             val line = getLine(cRow)
@@ -789,6 +820,9 @@ internal class MutationEngine(
             val start = maxOf(cCol, leftMargin)
             if (start <= rightMargin) {
                 annihilateAt(cRow, start)
+                if (rightMargin + 1 < width && line.rawCodepoint(rightMargin + 1) == TerminalConstants.WIDE_CHAR_SPACER) {
+                    annihilateAt(cRow, rightMargin + 1)
+                }
                 line.clearRange(start, rightMargin + 1, blankAttr, blankExtendedAttr)
                 state.markLineChanged(line)
             }

--- a/ketraterm-core/src/test/kotlin/io/github/ketraterm/core/buffer/TerminalLeftRightMarginTest.kt
+++ b/ketraterm-core/src/test/kotlin/io/github/ketraterm/core/buffer/TerminalLeftRightMarginTest.kt
@@ -17,9 +17,11 @@ package io.github.ketraterm.core.buffer
 
 import io.github.ketraterm.core.TerminalBuffers
 import io.github.ketraterm.core.api.TerminalBuffer
+import io.github.ketraterm.core.model.TerminalConstants
 import io.github.ketraterm.core.state.TerminalState
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class TerminalLeftRightMarginTest {
     private fun stateOf(api: TerminalBuffer): TerminalState {
@@ -573,5 +575,187 @@ class TerminalLeftRightMarginTest {
             { assertEquals('c'.code, buffer.getCodepointAt(4, 0)) },
             { assertEquals('R'.code, buffer.getCodepointAt(7, 0)) },
         )
+    }
+
+    @Test
+    fun `leftRightMargin_randomOperationsPropertyTest`() {
+        val buffer = TerminalBuffers.create(width = 10, height = 6)
+        val state = stateOf(buffer)
+        val random = Random(42)
+        val logs = ArrayList<String>()
+
+        try {
+            repeat(1000) { step ->
+                // Randomly enable or disable modes
+                if (random.nextInt(20) == 0) {
+                    val modeVal = random.nextBoolean()
+                    buffer.setLeftRightMarginMode(modeVal)
+                    logs.add("Step $step: setLeftRightMarginMode($modeVal)")
+                }
+                if (random.nextInt(20) == 0) {
+                    val modeVal = random.nextBoolean()
+                    buffer.setOriginMode(modeVal)
+                    logs.add("Step $step: setOriginMode($modeVal)")
+                }
+
+                // Randomly update margins
+                if (random.nextInt(15) == 0 && state.modes.isLeftRightMarginMode) {
+                    val left = random.nextInt(4) // 0..3
+                    val right = 5 + random.nextInt(4) // 5..8
+                    buffer.setLeftRightMargins(left + 1, right + 1)
+                    logs.add("Step $step: setLeftRightMargins(${left + 1}, ${right + 1})")
+                }
+                if (random.nextInt(15) == 0) {
+                    val top = random.nextInt(2) // 0..1
+                    val bottom = 3 + random.nextInt(2) // 3..4
+                    buffer.setScrollRegion(top + 1, bottom + 1)
+                    logs.add("Step $step: setScrollRegion(${top + 1}, ${bottom + 1})")
+                }
+
+                // Perform a random edit or cursor operation
+                when (random.nextInt(18)) {
+                    0 -> {
+                        val cp = 'A'.code + random.nextInt(26)
+                        buffer.writeCodepoint(cp)
+                        logs.add("Step $step: writeCodepoint(${cp.toChar()})")
+                    }
+                    1 -> {
+                        val cp = 0x1F600 + random.nextInt(5)
+                        buffer.writeCluster(intArrayOf(cp), 1)
+                        logs.add("Step $step: writeCluster(WideChar: $cp)")
+                    }
+                    2 -> {
+                        buffer.newLine()
+                        logs.add("Step $step: newLine()")
+                    }
+                    3 -> {
+                        buffer.carriageReturn()
+                        logs.add("Step $step: carriageReturn()")
+                    }
+                    4 -> {
+                        buffer.reverseLineFeed()
+                        logs.add("Step $step: reverseLineFeed()")
+                    }
+                    5 -> {
+                        val cnt = 1 + random.nextInt(2)
+                        buffer.insertLines(cnt)
+                        logs.add("Step $step: insertLines($cnt)")
+                    }
+                    6 -> {
+                        val cnt = 1 + random.nextInt(2)
+                        buffer.deleteLines(cnt)
+                        logs.add("Step $step: deleteLines($cnt)")
+                    }
+                    7 -> {
+                        val cnt = 1 + random.nextInt(3)
+                        buffer.insertBlankCharacters(cnt)
+                        logs.add("Step $step: insertBlankCharacters($cnt)")
+                    }
+                    8 -> {
+                        val cnt = 1 + random.nextInt(3)
+                        buffer.deleteCharacters(cnt)
+                        logs.add("Step $step: deleteCharacters($cnt)")
+                    }
+                    9 -> {
+                        val cnt = 1 + random.nextInt(3)
+                        buffer.eraseCharacters(cnt)
+                        logs.add("Step $step: eraseCharacters($cnt)")
+                    }
+                    10 -> {
+                        buffer.eraseLineToEnd()
+                        logs.add("Step $step: eraseLineToEnd()")
+                    }
+                    11 -> {
+                        buffer.eraseLineToCursor()
+                        logs.add("Step $step: eraseLineToCursor()")
+                    }
+                    12 -> {
+                        buffer.eraseCurrentLine()
+                        logs.add("Step $step: eraseCurrentLine()")
+                    }
+                    13 -> {
+                        buffer.scrollUp()
+                        logs.add("Step $step: scrollUp()")
+                    }
+                    14 -> {
+                        buffer.scrollDown()
+                        logs.add("Step $step: scrollDown()")
+                    }
+                    15 -> {
+                        val col = random.nextInt(12) - 1 // include out of bounds
+                        val row = random.nextInt(8) - 1
+                        buffer.positionCursor(col, row)
+                        logs.add("Step $step: positionCursor($col, $row)")
+                    }
+                    16 -> {
+                        val isSave = random.nextBoolean()
+                        if (isSave) {
+                            buffer.saveCursor()
+                            logs.add("Step $step: saveCursor()")
+                        } else {
+                            buffer.restoreCursor()
+                            logs.add("Step $step: restoreCursor()")
+                        }
+                    }
+                    else -> {
+                        buffer.writeText("xyz")
+                        logs.add("Step $step: writeText(xyz)")
+                    }
+                }
+
+                // INVARIANTS:
+                val cursorCol = buffer.cursorCol
+                val cursorRow = buffer.cursorRow
+
+                // Cursor row must always be in [0, height - 1]
+                assertTrue(cursorRow in 0 until buffer.height, "Step $step: Cursor row $cursorRow must be in 0..${buffer.height - 1}")
+                // Cursor col must always be in [0, width - 1]
+                assertTrue(cursorCol in 0 until buffer.width, "Step $step: Cursor col $cursorCol must be in 0..${buffer.width - 1}")
+
+                // If left/right margins are active (which effectiveLeftMargin/effectiveRightMargin represent),
+                // the cursor column must be within those margins.
+                val left = state.effectiveLeftMargin
+                val right = state.effectiveRightMargin
+                assertTrue(
+                    cursorCol in left..right,
+                    "Step $step: Cursor col $cursorCol must be in effective horizontal margins $left..$right",
+                )
+
+                // 2. No orphan spacer characters in the grid
+                for (r in 0 until buffer.height) {
+                    for (c in 0 until buffer.width) {
+                        val cp = buffer.getCodepointAt(c, r)
+                        if (cp == TerminalConstants.WIDE_CHAR_SPACER) {
+                            assertTrue(c > 0, "Step $step: WIDE_CHAR_SPACER cannot be in column 0 at row $r")
+                            val leader = buffer.getCodepointAt(c - 1, r)
+                            assertTrue(
+                                leader != TerminalConstants.EMPTY && leader != TerminalConstants.WIDE_CHAR_SPACER,
+                                "Step $step: Spacer at row=$r col=$c must have a non-empty leader on its left (was $leader)",
+                            )
+                        }
+                    }
+                }
+            }
+        } catch (e: Throwable) {
+            println("=== PROPERTY TEST FAILED ===")
+            println("Error: ${e.message}")
+            println("Steps leading to failure:")
+            logs.forEach { println("  $it") }
+            println("Grid content:")
+            for (r in 0 until buffer.height) {
+                val rowStr =
+                    (0 until buffer.width)
+                        .map { c ->
+                            val cp = buffer.getCodepointAt(c, r)
+                            when (cp) {
+                                TerminalConstants.EMPTY -> "."
+                                TerminalConstants.WIDE_CHAR_SPACER -> "S"
+                                else -> cp.toChar().toString()
+                            }
+                        }.joinToString("")
+                println("Row $r: $rowStr")
+            }
+            throw e
+        }
     }
 }

--- a/ketraterm-core/src/test/kotlin/io/github/ketraterm/core/buffer/TerminalScrollbackPolicyTest.kt
+++ b/ketraterm-core/src/test/kotlin/io/github/ketraterm/core/buffer/TerminalScrollbackPolicyTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Gagik Sargsyan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ketraterm.core.buffer
+
+import io.github.ketraterm.core.TerminalBuffers
+import io.github.ketraterm.core.api.TerminalBuffer
+import io.github.ketraterm.core.state.TerminalState
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TerminalScrollbackPolicyTest {
+    private fun stateOf(api: TerminalBuffer): TerminalState {
+        val componentsField = api.javaClass.getDeclaredField("components")
+        componentsField.isAccessible = true
+        val components = componentsField.get(api)
+
+        val stateField = components.javaClass.getDeclaredField("state")
+        stateField.isAccessible = true
+        return stateField.get(components) as TerminalState
+    }
+
+    @Test
+    fun `alternateBufferScrollbackIsolation_verifiesZeroHistoryAndNoLeakageToPrimary`() {
+        val buffer = TerminalBuffers.create(width = 10, height = 5, maxHistory = 10)
+        val state = stateOf(buffer)
+
+        // 1. Write text in primary buffer that triggers vertical scrolling.
+        // With height=5, writing 8 lines pushes 4 lines into primary scrollback history.
+        repeat(8) {
+            buffer.writeText("Line $it")
+            buffer.carriageReturn()
+            buffer.newLine()
+        }
+        val primaryHistorySize = (state.primaryBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertEquals(4, primaryHistorySize, "Primary buffer must have 4 history lines")
+
+        // Store primary history content to verify later.
+        val primaryHistoryContent =
+            (0 until primaryHistorySize).map { idx ->
+                val line = state.primaryBuffer.ring[idx]
+                (0 until 10).map { c -> line.rawCodepoint(c).toChar() }.joinToString("")
+            }
+
+        // 2. Switch to Alternate Screen Buffer
+        buffer.enterAltBuffer()
+        assertTrue(state.isAltScreenActive, "Alt screen must be active")
+        val altHistorySize = (state.altBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertEquals(0, altHistorySize, "Alt screen must have 0 history size")
+
+        // 3. Write lines to Alt buffer to cause scrolling.
+        // Alternate buffer has maxHistory=0, so scrolling should just discard/recycle lines, never grow history.
+        repeat(20) {
+            buffer.writeText("Alt line $it")
+            buffer.carriageReturn()
+            buffer.newLine()
+        }
+        val altHistorySizePost = (state.altBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertEquals(0, altHistorySizePost, "Alt screen history size must stay 0")
+
+        // 4. Return to Primary Screen Buffer
+        buffer.exitAltBuffer()
+        assertFalse(state.isAltScreenActive, "Primary screen must be active")
+
+        // Verify primary history is intact and unchanged.
+        val primaryHistorySizePost = (state.primaryBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertEquals(4, primaryHistorySizePost, "Primary history size must be preserved")
+        val postPrimaryHistoryContent =
+            (0 until primaryHistorySizePost).map { idx ->
+                val line = state.primaryBuffer.ring[idx]
+                (0 until 10).map { c -> line.rawCodepoint(c).toChar() }.joinToString("")
+            }
+        assertEquals(
+            primaryHistoryContent,
+            postPrimaryHistoryContent,
+            "Primary scrollback contents must not be modified by alt buffer edits",
+        )
+    }
+
+    @Test
+    fun `clearAllHistory_affectsOnlyPrimaryBuffer`() {
+        val buffer = TerminalBuffers.create(width = 10, height = 5, maxHistory = 10)
+        val state = stateOf(buffer)
+
+        // Write to push lines to primary scrollback
+        repeat(8) {
+            buffer.writeText("L $it")
+            buffer.carriageReturn()
+            buffer.newLine()
+        }
+        val primaryHistorySize = (state.primaryBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertTrue(primaryHistorySize > 0, "Primary buffer must have history")
+
+        // Clear history
+        buffer.clearAll()
+        val primaryHistorySizePost = (state.primaryBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertEquals(0, primaryHistorySizePost, "clearAll must clear primary history size")
+    }
+
+    @Test
+    fun `resizeWhileAltScreenActive_doesNotLeakOrCorruptHistory`() {
+        val buffer = TerminalBuffers.create(width = 10, height = 5, maxHistory = 10)
+        val state = stateOf(buffer)
+
+        // Generate primary scrollback
+        repeat(8) {
+            buffer.writeText("P $it")
+            buffer.carriageReturn()
+            buffer.newLine()
+        }
+        val origHistorySize = (state.primaryBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertTrue(origHistorySize > 0)
+
+        // Enter alt screen
+        buffer.enterAltBuffer()
+        buffer.writeText("Alt text")
+
+        // Resize buffer while alt screen is active
+        buffer.resize(12, 6)
+
+        // Verify active buffer is resized and is still the alt screen with 0 history
+        assertTrue(state.isAltScreenActive)
+        val altHistorySize = (state.altBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertEquals(0, altHistorySize)
+        assertEquals(12, state.dimensions.width)
+        assertEquals(6, state.dimensions.height)
+
+        // Exit alt screen and verify primary buffer reflowed / resized without corruption
+        buffer.exitAltBuffer()
+        assertFalse(state.isAltScreenActive)
+        assertEquals(12, state.dimensions.width)
+        assertEquals(6, state.dimensions.height)
+        // Primary history should still exist (reflowed or clipped accordingly)
+        val primaryHistorySize = (state.primaryBuffer.ring.size - state.dimensions.height).coerceAtLeast(0)
+        assertTrue(primaryHistorySize >= 0)
+    }
+}

--- a/ketraterm-parser/src/test/kotlin/io/github/ketraterm/parser/utf8/Utf8DecoderTest.kt
+++ b/ketraterm-parser/src/test/kotlin/io/github/ketraterm/parser/utf8/Utf8DecoderTest.kt
@@ -430,4 +430,98 @@ class Utf8DecoderTest {
             assertEquals(listOf('?'.code), decodeAll(0xE2, 0x82, decoder = decoder, flushEndOfInput = true))
         }
     }
+
+    // ----- Structural boundary tests ---------------------------------------
+
+    @Nested
+    @DisplayName("structural boundary tests")
+    inner class StructuralBoundaryTests {
+        @Test
+        fun `2-byte sequence boundary cases`() {
+            // Valid lead + ASCII byte: expects replacement then reprocesses follow
+            val d1 = Utf8Decoder()
+            assertNoOutput(d1.accept(0xC2))
+            assertEmit(d1.accept('A'.code), replacement(), expectedReprocess = true)
+
+            // Valid lead + invalid continuation lead byte: expects replacement then reprocesses follow
+            val d2 = Utf8Decoder()
+            assertNoOutput(d2.accept(0xC2))
+            assertEmit(d2.accept(0xC3), replacement(), expectedReprocess = true)
+        }
+
+        @Test
+        fun `3-byte sequence boundary cases`() {
+            // Lead + ASCII at first continuation byte
+            val d1 = Utf8Decoder()
+            assertNoOutput(d1.accept(0xE1))
+            assertEmit(d1.accept('A'.code), replacement(), expectedReprocess = true)
+
+            // Lead + valid continuation + ASCII at second continuation byte
+            val d2 = Utf8Decoder()
+            assertNoOutput(d2.accept(0xE1))
+            assertNoOutput(d2.accept(0x80))
+            assertEmit(d2.accept('A'.code), replacement(), expectedReprocess = true)
+
+            // Lead + valid continuation + non-continuation lead byte at second continuation byte
+            val d3 = Utf8Decoder()
+            assertNoOutput(d3.accept(0xE1))
+            assertNoOutput(d3.accept(0x80))
+            assertEmit(d3.accept(0xC3), replacement(), expectedReprocess = true)
+        }
+
+        @Test
+        fun `4-byte sequence boundary cases`() {
+            // Lead + ASCII at first continuation byte
+            val d1 = Utf8Decoder()
+            assertNoOutput(d1.accept(0xF1))
+            assertEmit(d1.accept('A'.code), replacement(), expectedReprocess = true)
+
+            // Lead + valid continuation + ASCII at second continuation byte
+            val d2 = Utf8Decoder()
+            assertNoOutput(d2.accept(0xF1))
+            assertNoOutput(d2.accept(0x80))
+            assertEmit(d2.accept('A'.code), replacement(), expectedReprocess = true)
+
+            // Lead + valid continuation + valid continuation + ASCII at third continuation byte
+            val d3 = Utf8Decoder()
+            assertNoOutput(d3.accept(0xF1))
+            assertNoOutput(d3.accept(0x80))
+            assertNoOutput(d3.accept(0x80))
+            assertEmit(d3.accept('A'.code), replacement(), expectedReprocess = true)
+
+            // Lead + valid continuation + valid continuation + non-continuation lead byte at third continuation byte
+            val d4 = Utf8Decoder()
+            assertNoOutput(d4.accept(0xF1))
+            assertNoOutput(d4.accept(0x80))
+            assertNoOutput(d4.accept(0x80))
+            assertEmit(d4.accept(0xC3), replacement(), expectedReprocess = true)
+        }
+
+        @Test
+        fun `overlong and surrogate boundaries without reprocess`() {
+            // 3-byte overlong lead: 0xE0 followed by 0x80 (is in 0x80..0xBF, but not in 0xA0..0xBF)
+            // Expects replacement without reprocessing 0x80 because 0x80 is in 0x80..0xBF
+            val d1 = Utf8Decoder()
+            assertNoOutput(d1.accept(0xE0))
+            assertEmit(d1.accept(0x80), replacement(), expectedReprocess = false)
+
+            // Surrogate lead: 0xED followed by 0xA0 (is in 0x80..0xBF, but not in 0x80..0x9F)
+            // Expects replacement without reprocessing 0xA0
+            val d2 = Utf8Decoder()
+            assertNoOutput(d2.accept(0xED))
+            assertEmit(d2.accept(0xA0), replacement(), expectedReprocess = false)
+
+            // 4-byte overlong lead: 0xF0 followed by 0x80 (is in 0x80..0xBF, but not in 0x90..0xBF)
+            // Expects replacement without reprocessing 0x80
+            val d3 = Utf8Decoder()
+            assertNoOutput(d3.accept(0xF0))
+            assertEmit(d3.accept(0x80), replacement(), expectedReprocess = false)
+
+            // Out-of-unicode boundary: 0xF4 followed by 0x90 (is in 0x80..0xBF, but not in 0x80..0x8F)
+            // Expects replacement without reprocessing 0x90
+            val d4 = Utf8Decoder()
+            assertNoOutput(d4.accept(0xF4))
+            assertEmit(d4.accept(0x90), replacement(), expectedReprocess = false)
+        }
+    }
 }


### PR DESCRIPTION
…sics

- Fix a grid physics bug in `MutationEngine` where shifting, clearing, or copying cells at margin boundaries (e.g. `rightMargin + 1`) could leave wide character spacers orphaned when their leaders were cleared or moved.
- Implement comprehensive UTF-8 boundary and split-stream chunking tests in `Utf8DecoderTest`.
- Add a 1000-step randomized property fuzzer in `TerminalLeftRightMarginTest` to continuously assert cursor-in-margin and spacer-integrity invariants.
- Implement `TerminalScrollbackPolicyTest` to verify alt-screen scrollback isolation, alternate buffer lifecycle, and resizing.
- Apply spotless formatting cleanup across all modified modules.