### PR TITLE
fix(ui-swing): resolve AltGr character input and terminal grid corruption

### DIFF
--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingKeyMapper.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingKeyMapper.kt
@@ -118,9 +118,15 @@ internal class SwingKeyMapper {
     private fun modifiers(event: KeyEvent): Int {
         var modifiers = TerminalModifiers.NONE
         if (event.isShiftDown) modifiers = modifiers or TerminalModifiers.SHIFT
-        if (event.isAltDown || event.isAltGraphDown) modifiers = modifiers or TerminalModifiers.ALT
-        if (event.isControlDown) modifiers = modifiers or TerminalModifiers.CTRL
         if (event.isMetaDown) modifiers = modifiers or TerminalModifiers.META
+
+        if (event.isAltGraphDown) {
+            // AltGr is active. On Windows/Linux, this sets isControlDown and isAltDown.
+            // We do not map these to terminal modifiers.
+        } else {
+            if (event.isAltDown) modifiers = modifiers or TerminalModifiers.ALT
+            if (event.isControlDown) modifiers = modifiers or TerminalModifiers.CTRL
+        }
         return modifiers
     }
 

--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalInputController.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalInputController.kt
@@ -34,10 +34,13 @@ internal class SwingTerminalInputController(
             override fun keyPressed(event: KeyEvent) {
                 host.updateHyperlinkActivationHover(event.isControlDown)
                 host.resetCursorBlink(forceRepaint = true)
-                if (host.handleShellSuggestionKeyPressed(event)) return
-                if (handleViewportScrollShortcut(event)) return
-                if (handleSearchShortcut(event)) return
-                if (handleClipboardShortcut(event)) return
+
+                if (!event.isAltGraphDown) {
+                    if (host.handleShellSuggestionKeyPressed(event)) return
+                    if (handleViewportScrollShortcut(event)) return
+                    if (handleSearchShortcut(event)) return
+                    if (handleClipboardShortcut(event)) return
+                }
 
                 val keyEvent = keyMapper.keyPressed(event) ?: return
                 host.session?.encodeKey(keyEvent)

--- a/ketraterm-ui-swing/src/test/kotlin/io/github/ketraterm/ui/swing/input/SwingKeyMapperTest.kt
+++ b/ketraterm-ui-swing/src/test/kotlin/io/github/ketraterm/ui/swing/input/SwingKeyMapperTest.kt
@@ -119,6 +119,31 @@ class SwingKeyMapperTest {
         assertNull(mapper.keyPressed(pressed(KeyEvent.VK_A)))
     }
 
+    @Test
+    fun ignoresAltGrKeyPressedForPrintableCharacters() {
+        val modifiers = KeyEvent.CTRL_DOWN_MASK or KeyEvent.ALT_DOWN_MASK or KeyEvent.ALT_GRAPH_DOWN_MASK
+        val mapped = mapper.keyPressed(pressed(KeyEvent.VK_0, modifiers = modifiers))
+        assertNull(mapped)
+    }
+
+    @Test
+    fun mapsAltGrKeyTypedCharacterWithoutCtrlAltModifiers() {
+        val modifiers = KeyEvent.CTRL_DOWN_MASK or KeyEvent.ALT_DOWN_MASK or KeyEvent.ALT_GRAPH_DOWN_MASK
+        val mapped = mapper.keyTyped(typed('@', modifiers = modifiers))
+
+        assertEquals('@'.code, mapped?.codepoint)
+        assertEquals(TerminalModifiers.NONE, mapped?.modifiers)
+    }
+
+    @Test
+    fun mapsShiftAltGrKeyTypedCharacterWithShiftModifier() {
+        val modifiers = KeyEvent.CTRL_DOWN_MASK or KeyEvent.ALT_DOWN_MASK or KeyEvent.ALT_GRAPH_DOWN_MASK or KeyEvent.SHIFT_DOWN_MASK
+        val mapped = mapper.keyTyped(typed('Ω', modifiers = modifiers))
+
+        assertEquals('Ω'.code, mapped?.codepoint)
+        assertEquals(TerminalModifiers.SHIFT, mapped?.modifiers)
+    }
+
     private fun typed(
         char: Char,
         modifiers: Int = 0,


### PR DESCRIPTION
Fixes: #86 

On Windows and Linux platforms, pressing the AltGr key (commonly used on non-US layouts like French AZERTY to type characters like '@', '[', ']', '{', '}', '\') causes Java AWT/Swing to report both CTRL and ALT modifiers as active on keyboard events.

This had two major side-effects in KetraTerm:
1. `keyPressed` interpreted AltGr combinations as control shortcuts (e.g., Ctrl+Alt+0) and consumed them, suppressing the follow-up `KEY_TYPED` events needed to output printable characters.
2. If mapped, the legacy and Kitty encoders translated the Ctrl+Alt state into command sequences (like modifyOtherKeys or Ctrl+Alt key codes) that shells misinterpret as readline/editing commands, leading to display and cursor grid corruption.

This patch fixes the issue by:
- Modifying `SwingKeyMapper` to strip CTRL and ALT modifiers when `event.isAltGraphDown` is true, resolving them back to standard layout-neutral keyboard events.
- Bypassing AWT/Swing shortcut listeners (search, clipboard, and shell suggestions) in `SwingTerminalInputController` when AltGr is held, allowing key-press events to fall through cleanly.
- Adding tests to `SwingKeyMapperTest` to assert AltGr character and Shift+AltGr input behaviors.