### PR TITLE
fix(ui): request focus on any mouse press within SwingTerminal

### DIFF
--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/api/SwingTerminal.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/api/SwingTerminal.kt
@@ -311,6 +311,8 @@ class SwingTerminal
 
                     override fun pasteClipboardText(): Boolean = this@SwingTerminal.pasteClipboardText()
 
+                    override fun requestFocusInWindow(): Boolean = this@SwingTerminal.requestFocusInWindow()
+
                     override fun handlePromptMarkerMousePressed(event: MouseEvent): Boolean =
                         this@SwingTerminal.handlePromptMarkerMousePressed(event)
 

--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseController.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseController.kt
@@ -39,6 +39,7 @@ internal class SwingTerminalMouseController(
     val mouseListener =
         object : MouseAdapter() {
             override fun mousePressed(event: MouseEvent) {
+                host.requestFocusInWindow()
                 if (host.handlePromptMarkerMousePressed(event)) return
                 if (handleMouseTracking(event, TerminalMouseEventType.PRESS)) return
                 if (host.handleHyperlinkMousePressed(event)) return

--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseHost.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseHost.kt
@@ -53,6 +53,8 @@ internal interface SwingTerminalMouseHost {
 
     fun pasteClipboardText(): Boolean
 
+    fun requestFocusInWindow(): Boolean
+
     fun handlePromptMarkerMousePressed(event: MouseEvent): Boolean = false
 
     fun handlePromptMarkerMouseMoved(event: MouseEvent): Boolean = false

--- a/ketraterm-ui-swing/src/test/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseControllerTest.kt
+++ b/ketraterm-ui-swing/src/test/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseControllerTest.kt
@@ -72,6 +72,19 @@ class SwingTerminalMouseControllerTest {
             assertEquals(1, host.hyperlinkPressCount)
             assertEquals(0, host.selectionPressCount)
         }
+
+        @Test
+        fun `mouse press requests focus in window even when mouse tracking is active`() {
+            val host = RecordingMouseHost(mouseTrackingMode = MouseTrackingMode.NORMAL)
+            val controller = SwingTerminalMouseController(host)
+            val event = mousePressed(button = MouseEvent.BUTTON1, modifiers = InputEvent.BUTTON1_DOWN_MASK)
+
+            controller.mouseListener.mousePressed(event)
+
+            assertEquals(1, host.requestFocusInWindowCount)
+            assertEquals(1, host.mouseReports.size)
+            assertTrue(event.isConsumed)
+        }
     }
 
     @Nested
@@ -301,6 +314,7 @@ class SwingTerminalMouseControllerTest {
 
         var scrollCount = 0
         var pasteCount = 0
+        var requestFocusInWindowCount = 0
         var hyperlinkPressCount = 0
         var hyperlinkMoveCount = 0
         var hyperlinkExitCount = 0
@@ -343,6 +357,11 @@ class SwingTerminalMouseControllerTest {
 
         override fun pasteClipboardText(): Boolean {
             pasteCount++
+            return true
+        }
+
+        override fun requestFocusInWindow(): Boolean {
+            requestFocusInWindowCount++
             return true
         }
 


### PR DESCRIPTION
fixes: #85 
Ensure that the terminal component requests keyboard focus on any mouse press, regardless of whether the event is subsequently consumed by mouse tracking (Vim/Neovim/Claude Code), hyperlink triggers, or prompt gutter clicks. Previously, the focus request was only made in the selection handler, meaning clicks in active tracking mode never focused the component, leaving focus stuck in the editor.