### PR TITLE
feat(ui-swing): emulate cursor keys on mouse wheel in alternate buffer

### DIFF
--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/api/SwingTerminal.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/api/SwingTerminal.kt
@@ -15,6 +15,7 @@
  */
 package io.github.ketraterm.ui.swing.api
 
+import io.github.ketraterm.input.api.TerminalInputEncoder
 import io.github.ketraterm.input.event.TerminalMouseEvent
 import io.github.ketraterm.input.event.TerminalPasteEvent
 import io.github.ketraterm.protocol.MouseTrackingMode
@@ -329,6 +330,7 @@ class SwingTerminal
                     override val settings: SwingSettings get() = this@SwingTerminal.settings
                     override val metrics: SwingMetrics get() = this@SwingTerminal.metrics
                     override val renderCache: TerminalRenderCache get() = this@SwingTerminal.renderCache
+                    override val session: TerminalInputEncoder? get() = this@SwingTerminal.session
 
                     override fun mouseTrackingMode(): MouseTrackingMode =
                         this@SwingTerminal

--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseController.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseController.kt
@@ -15,11 +15,9 @@
  */
 package io.github.ketraterm.ui.swing.input
 
-import io.github.ketraterm.input.event.TerminalModifiers
-import io.github.ketraterm.input.event.TerminalMouseButton
-import io.github.ketraterm.input.event.TerminalMouseEvent
-import io.github.ketraterm.input.event.TerminalMouseEventType
+import io.github.ketraterm.input.event.*
 import io.github.ketraterm.protocol.MouseTrackingMode
+import io.github.ketraterm.render.api.TerminalRenderBufferKind
 import io.github.ketraterm.ui.swing.settings.SwingTerminalChrome
 import java.awt.event.*
 import javax.swing.SwingUtilities
@@ -91,6 +89,20 @@ internal class SwingTerminalMouseController(
         }
         val delta = wheelScrollLines(event)
         if (delta == 0.0) {
+            event.consume()
+            return
+        }
+
+        if (host.renderCache.activeBuffer == TerminalRenderBufferKind.ALTERNATE) {
+            val key = if (delta > 0.0) TerminalKey.UP else TerminalKey.DOWN
+            val count = kotlin.math.round(kotlin.math.abs(delta)).toInt()
+            val session = host.session
+            if (session != null && count > 0) {
+                val keyEvent = TerminalKeyEvent.key(key)
+                for (i in 0 until count) {
+                    session.encodeKey(keyEvent)
+                }
+            }
             event.consume()
             return
         }

--- a/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseHost.kt
+++ b/ketraterm-ui-swing/src/main/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseHost.kt
@@ -15,6 +15,7 @@
  */
 package io.github.ketraterm.ui.swing.input
 
+import io.github.ketraterm.input.api.TerminalInputEncoder
 import io.github.ketraterm.input.event.TerminalMouseEvent
 import io.github.ketraterm.protocol.MouseTrackingMode
 import io.github.ketraterm.render.cache.TerminalRenderCache
@@ -29,6 +30,7 @@ internal interface SwingTerminalMouseHost {
     val settings: SwingSettings
     val metrics: SwingMetrics
     val renderCache: TerminalRenderCache
+    val session: TerminalInputEncoder?
 
     fun mouseTrackingMode(): MouseTrackingMode
 

--- a/ketraterm-ui-swing/src/test/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseControllerTest.kt
+++ b/ketraterm-ui-swing/src/test/kotlin/io/github/ketraterm/ui/swing/input/SwingTerminalMouseControllerTest.kt
@@ -15,6 +15,8 @@
  */
 package io.github.ketraterm.ui.swing.input
 
+import io.github.ketraterm.input.api.TerminalInputEncoder
+import io.github.ketraterm.input.event.TerminalKey
 import io.github.ketraterm.input.event.TerminalMouseEvent
 import io.github.ketraterm.protocol.MouseTrackingMode
 import io.github.ketraterm.render.api.*
@@ -182,6 +184,85 @@ class SwingTerminalMouseControllerTest {
             assertEquals(0, host.scrollCount)
             assertTrue(event.isConsumed)
         }
+
+        @Test
+        fun `scroll up in alternate screen buffer with mouse tracking off translates to UP keys`() {
+            val encodedKeys = ArrayList<io.github.ketraterm.input.event.TerminalKeyEvent>()
+            val fakeSession =
+                object : TerminalInputEncoder {
+                    override fun encodeKey(event: io.github.ketraterm.input.event.TerminalKeyEvent) {
+                        encodedKeys += event
+                    }
+
+                    override fun encodePaste(event: io.github.ketraterm.input.event.TerminalPasteEvent) {}
+
+                    override fun encodeFocus(event: io.github.ketraterm.input.event.TerminalFocusEvent) {}
+
+                    override fun encodeMouse(event: TerminalMouseEvent) {}
+                }
+
+            val host = RecordingMouseHost(session = fakeSession)
+            host.renderCache.updateFrom(
+                FakeFrameReader(FakeFrame(historySize = 0, rows = 24, activeBuffer = TerminalRenderBufferKind.ALTERNATE)),
+            )
+            val controller = SwingTerminalMouseController(host)
+
+            // rotation = -1.0 means scrolling UP (clicks = 1.0, delta = 3.0)
+            val event = mouseWheel(rotation = -1.0)
+            controller.wheelListener.mouseWheelMoved(event)
+
+            assertEquals(3, encodedKeys.size)
+            assertTrue(encodedKeys.all { it.key == TerminalKey.UP })
+            assertEquals(0, host.scrollCount)
+            assertTrue(event.isConsumed)
+        }
+
+        @Test
+        fun `scroll down in alternate screen buffer with mouse tracking off translates to DOWN keys`() {
+            val encodedKeys = ArrayList<io.github.ketraterm.input.event.TerminalKeyEvent>()
+            val fakeSession =
+                object : TerminalInputEncoder {
+                    override fun encodeKey(event: io.github.ketraterm.input.event.TerminalKeyEvent) {
+                        encodedKeys += event
+                    }
+
+                    override fun encodePaste(event: io.github.ketraterm.input.event.TerminalPasteEvent) {}
+
+                    override fun encodeFocus(event: io.github.ketraterm.input.event.TerminalFocusEvent) {}
+
+                    override fun encodeMouse(event: TerminalMouseEvent) {}
+                }
+
+            val host = RecordingMouseHost(session = fakeSession)
+            host.renderCache.updateFrom(
+                FakeFrameReader(FakeFrame(historySize = 0, rows = 24, activeBuffer = TerminalRenderBufferKind.ALTERNATE)),
+            )
+            val controller = SwingTerminalMouseController(host)
+
+            // rotation = 1.0 means scrolling DOWN (clicks = -1.0, delta = -3.0)
+            val event = mouseWheel(rotation = 1.0)
+            controller.wheelListener.mouseWheelMoved(event)
+
+            assertEquals(3, encodedKeys.size)
+            assertTrue(encodedKeys.all { it.key == TerminalKey.DOWN })
+            assertEquals(0, host.scrollCount)
+            assertTrue(event.isConsumed)
+        }
+
+        @Test
+        fun `scroll in alternate screen buffer does not crash and consumes event when session is null`() {
+            val host = RecordingMouseHost(session = null)
+            host.renderCache.updateFrom(
+                FakeFrameReader(FakeFrame(historySize = 0, rows = 24, activeBuffer = TerminalRenderBufferKind.ALTERNATE)),
+            )
+            val controller = SwingTerminalMouseController(host)
+
+            val event = mouseWheel(rotation = -1.0)
+            controller.wheelListener.mouseWheelMoved(event)
+
+            assertEquals(0, host.scrollCount)
+            assertTrue(event.isConsumed)
+        }
     }
 
     @Nested
@@ -299,6 +380,7 @@ class SwingTerminalMouseControllerTest {
         private val hyperlinkPressHandled: Boolean = false,
         private val scrollResult: Boolean = true,
         private val mouseTrackingMode: MouseTrackingMode = MouseTrackingMode.OFF,
+        override val session: TerminalInputEncoder? = null,
     ) : SwingTerminalMouseHost {
         override val metrics =
             SwingMetrics(
@@ -421,12 +503,12 @@ class SwingTerminalMouseControllerTest {
     private class FakeFrame(
         override val historySize: Int,
         override val rows: Int,
+        override val activeBuffer: TerminalRenderBufferKind = TerminalRenderBufferKind.PRIMARY,
     ) : TerminalRenderFrame {
         override val columns: Int = 80
         override val scrollbackOffset: Int = 0
         override val frameGeneration: Long = 1L
         override val structureGeneration: Long = 1L
-        override val activeBuffer: TerminalRenderBufferKind = TerminalRenderBufferKind.PRIMARY
         override val cursor = TerminalRenderCursor(0, 0, false, false, TerminalRenderCursorShape.BLOCK, 1L)
         override val discardedCount: Long = 0L
 


### PR DESCRIPTION
Fixes: #84

When a full-screen TUI application (such as `codex`, `less`, or `vim`) is active in the alternate screen buffer and mouse tracking is disabled, mouse wheel scrolling currently does nothing because the alternate buffer has no scrollback history.

This change translates mouse wheel scroll events into emulated `TerminalKey.UP` and `TerminalKey.DOWN` arrow key events when the terminal is in the `ALTERNATE` buffer and mouse tracking is disabled.

- Add `session: TerminalInputEncoder?` to `SwingTerminalMouseHost`
- Map scroll wheel delta to Arrow Up/Down keys in `SwingTerminalMouseController`
- Add unit tests verifying scroll translation direction, counts, and null sessions