### PR TITLE
docs: update terminal feature and feature gap maps

### DIFF
--- a/docs/terminal-feature-gap-map.md
+++ b/docs/terminal-feature-gap-map.md
@@ -150,8 +150,8 @@ These are not badges of compatibility for this project. They expand attack surfa
 
 - `TODO(host)`: richer font fallback policy, bundled/host-provided font resolver host, script/run-level shaping, and fallback cache eviction.
 - `TODO(host)`: richer font measurement policy for script/run-level shaping, fallback run metrics, and backend painter integrations beyond the current Java2D/Swing path.
-- `TODO(host)`: custom line spacing/height metrics in the renderer.
-- `TODO(host/ui)`: richer UI scrollback controls, selection behavior while scrolled, and auto-follow/offset-retention policy beyond the current fixed-grid Swing scrollbar and viewport mapping.
+- `DONE(host)`: custom line spacing/height metrics in the renderer.
+- `DONE(host/ui)`: scrollback controls, selection behavior while scrolled, scroll-on-output policy, and resize offset retention.
 - `TODO(host/ui)`: live shell suggestion triggers, command-line replacement semantics, path/current-directory providers, and IntelliJ-native popup styling remain host-owned follow-up work. The reusable Swing terminal popup surface, keyboard/mouse selection, acceptance callback, standalone history provider, and standalone/IntelliJ enablement settings exist.
 - `TODO(host)`: accessibility/export APIs.
 - `TODO(host)`: performance benchmarks for large scrollback, resize, and dense SGR streams.

--- a/docs/terminal-feature-map.md
+++ b/docs/terminal-feature-map.md
@@ -104,6 +104,8 @@ For a detailed backlog of gaps and intentional non-goals, see the [Terminal Feat
 ## 7. Embedding & Swing UI
 
 - **PTY Process Integration**: Spawns default platform shells using Pty4J with Windows ConPTY support and prompt resizing.
+- **Custom Line Height**: Dynamic line spacing/height scaling (from 0.5x to 3.0x) supported in settings and rendered in the Swing UI.
+- **Scrollback & Selection Policies**: Auto-follow (`scrollOnOutput`) configuration, resize viewport offset-retention, and clipboard copy operations spanning the full scrollback history.
 - **High-Performance Painting**: Decoupled, multi-threaded rendering using triple-buffering to achieve 60+ FPS paint cycles with zero tearing under heavy stdout throughput.
 - **Font Fallbacks**: Scan and fall back to native system fonts for color emojis and complex visual shapes.
 - **Windows Emoji Rasterizer**: Segoe UI Emoji COLR/CPAL color glyph painting.


### PR DESCRIPTION
- Update terminal-feature-map.md to include Custom Line Height and Scrollback & Selection Policies under embedding and Swing features.

- Update terminal-feature-gap-map.md to mark renderer line-height scaling and scrollback controls/policies as DONE.