### PR TITLE
Ensure UTF-8 recovery prevents malformed bytes from leaking or dispat…

### DIFF
--- a/docs/terminal-feature-gap-map.md
+++ b/docs/terminal-feature-gap-map.md
@@ -82,7 +82,9 @@ These are not badges of compatibility for this project. They expand attack surfa
 - `TODO(policy)`: any DCS that can exfiltrate host capabilities needs a response policy and terminal-to-host channel.
 
 ### Text and Unicode
-- `TODO(parser)`: malformed UTF-8 policy tests across all structural boundary bytes.
+- `DONE(parser)`: malformed UTF-8 recovery is exercised immediately before and inside ESC, CSI,
+  OSC (BEL/ST/CAN/SUB), DCS ST, and end-of-input, with every split boundary proving that malformed
+  bytes do not print or complete stale structural commands.
 - `TODO(parser)`: configurable replacement policy if needed by host applications.
 - `TODO(parser)`: broader ISO 2022 charset mapping.
 

--- a/ketraterm-parser/src/main/kotlin/io/github/ketraterm/parser/ansi/AnsiStateMachine.kt
+++ b/ketraterm-parser/src/main/kotlin/io/github/ketraterm/parser/ansi/AnsiStateMachine.kt
@@ -134,6 +134,10 @@ internal object AnsiStateMachine {
     private fun buildEscape() {
         val s = AnsiState.ESCAPE
 
+        // A non-ASCII byte cannot be an ESC final.  Drop the incomplete ESC sequence so a
+        // malformed UTF-8 lead cannot make a later ASCII byte dispatch the stale sequence.
+        set(s, ByteClass.UTF8_PAYLOAD, AnsiState.GROUND, FsmAction.CLEAR_SEQUENCE)
+
         set(s, ByteClass.INTERMEDIATE, AnsiState.ESCAPE_INTERMEDIATE, FsmAction.COLLECT_INTERMEDIATE)
 
         set(s, ByteClass.CSI_INTRO, AnsiState.CSI_ENTRY, FsmAction.CLEAR_SEQUENCE)
@@ -154,6 +158,9 @@ internal object AnsiStateMachine {
     private fun buildEscapeIntermediate() {
         val s = AnsiState.ESCAPE_INTERMEDIATE
 
+        // See ESCAPE: UTF-8 is not valid in an ESC control function.
+        set(s, ByteClass.UTF8_PAYLOAD, AnsiState.GROUND, FsmAction.CLEAR_SEQUENCE)
+
         set(s, ByteClass.INTERMEDIATE, s, FsmAction.COLLECT_INTERMEDIATE)
 
         set(s, ByteClass.PARAM_DIGIT, AnsiState.GROUND, FsmAction.ESC_DISPATCH)
@@ -169,6 +176,12 @@ internal object AnsiStateMachine {
     }
 
     private fun buildCsi() {
+        // Non-ASCII bytes are invalid in CSI control functions.  Keep consuming through
+        // CSI_IGNORE until a structural terminator so no accumulated parameters dispatch.
+        set(AnsiState.CSI_ENTRY, ByteClass.UTF8_PAYLOAD, AnsiState.CSI_IGNORE, FsmAction.IGNORE)
+        set(AnsiState.CSI_PARAM, ByteClass.UTF8_PAYLOAD, AnsiState.CSI_IGNORE, FsmAction.IGNORE)
+        set(AnsiState.CSI_INTERMEDIATE, ByteClass.UTF8_PAYLOAD, AnsiState.CSI_IGNORE, FsmAction.IGNORE)
+
         // CSI_ENTRY
         set(AnsiState.CSI_ENTRY, ByteClass.PARAM_DIGIT, AnsiState.CSI_PARAM, FsmAction.PARAM_DIGIT)
         set(AnsiState.CSI_ENTRY, ByteClass.COLON, AnsiState.CSI_PARAM, FsmAction.PARAM_COLON)
@@ -255,6 +268,9 @@ internal object AnsiStateMachine {
         set(AnsiState.DCS_ENTRY, ByteClass.OSC_INTRO, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
         set(AnsiState.DCS_ENTRY, ByteClass.SOS_PM_APC_INTRO, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
         set(AnsiState.DCS_ENTRY, ByteClass.FINAL_BYTE, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
+        // A malformed UTF-8 byte before the DCS introducer has completed must not be replayed
+        // as a query once later ASCII completes it.  Swallow the remainder through ST/CAN/SUB.
+        set(AnsiState.DCS_ENTRY, ByteClass.UTF8_PAYLOAD, AnsiState.IGNORE_UNTIL_ST, FsmAction.STRING_END)
 
         val s = AnsiState.DCS_PASSTHROUGH
         set(s, ByteClass.INTERMEDIATE, s, FsmAction.DCS_PUT_ASCII)
@@ -275,7 +291,8 @@ internal object AnsiStateMachine {
         // OSC string body
         // ---------------------------------------------------------------------
         set(AnsiState.OSC_STRING, ByteClass.EXECUTE, AnsiState.OSC_STRING, FsmAction.OSC_EXECUTE_CONTROL)
-        set(AnsiState.OSC_STRING, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.OSC_END)
+        // CAN/SUB abort OSC; unlike BEL/ST they must discard, never dispatch, the partial payload.
+        set(AnsiState.OSC_STRING, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END)
         set(AnsiState.OSC_STRING, ByteClass.ESC, AnsiState.OSC_ESCAPE, FsmAction.IGNORE)
 
         // ESC \ terminates OSC.
@@ -283,7 +300,7 @@ internal object AnsiStateMachine {
 
         // Anything else after ESC inside OSC resumes OSC payload handling.
         set(AnsiState.OSC_ESCAPE, ByteClass.EXECUTE, AnsiState.OSC_STRING, FsmAction.OSC_EXECUTE_CONTROL)
-        set(AnsiState.OSC_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.OSC_END)
+        set(AnsiState.OSC_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END)
         set(AnsiState.OSC_ESCAPE, ByteClass.ESC, AnsiState.OSC_ESCAPE, FsmAction.IGNORE)
         set(AnsiState.OSC_ESCAPE, ByteClass.UTF8_PAYLOAD, AnsiState.OSC_STRING, FsmAction.OSC_PUT_UTF8)
 
@@ -294,7 +311,8 @@ internal object AnsiStateMachine {
         // ---------------------------------------------------------------------
         // In DCS passthrough, ordinary C0 is retained as payload, not executed.
         set(AnsiState.DCS_PASSTHROUGH, ByteClass.EXECUTE, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_PUT_ASCII)
-        set(AnsiState.DCS_PASSTHROUGH, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.DCS_END)
+        // CAN/SUB abort DCS before any bounded payload can reach a dispatcher.
+        set(AnsiState.DCS_PASSTHROUGH, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END)
         set(AnsiState.DCS_PASSTHROUGH, ByteClass.ESC, AnsiState.DCS_ESCAPE, FsmAction.IGNORE)
 
         // ESC \ terminates DCS.
@@ -302,7 +320,7 @@ internal object AnsiStateMachine {
 
         // Anything else after ESC inside DCS resumes DCS payload handling.
         set(AnsiState.DCS_ESCAPE, ByteClass.EXECUTE, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_PUT_ASCII)
-        set(AnsiState.DCS_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.DCS_END)
+        set(AnsiState.DCS_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END)
         set(AnsiState.DCS_ESCAPE, ByteClass.ESC, AnsiState.DCS_ESCAPE, FsmAction.IGNORE)
         set(AnsiState.DCS_ESCAPE, ByteClass.UTF8_PAYLOAD, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_PUT_UTF8)
 

--- a/ketraterm-parser/src/main/kotlin/io/github/ketraterm/parser/ansi/AnsiStateMachine.kt
+++ b/ketraterm-parser/src/main/kotlin/io/github/ketraterm/parser/ansi/AnsiStateMachine.kt
@@ -176,11 +176,12 @@ internal object AnsiStateMachine {
     }
 
     private fun buildCsi() {
-        // Non-ASCII bytes are invalid in CSI control functions.  Keep consuming through
-        // CSI_IGNORE until a structural terminator so no accumulated parameters dispatch.
-        set(AnsiState.CSI_ENTRY, ByteClass.UTF8_PAYLOAD, AnsiState.CSI_IGNORE, FsmAction.IGNORE)
-        set(AnsiState.CSI_PARAM, ByteClass.UTF8_PAYLOAD, AnsiState.CSI_IGNORE, FsmAction.IGNORE)
-        set(AnsiState.CSI_INTERMEDIATE, ByteClass.UTF8_PAYLOAD, AnsiState.CSI_IGNORE, FsmAction.IGNORE)
+        // Non-ASCII bytes are invalid in CSI control functions. Drop the incomplete sequence
+        // immediately so a later ASCII final is ordinary text, never a stale CSI dispatch.
+        set(AnsiState.CSI_ENTRY, ByteClass.UTF8_PAYLOAD, AnsiState.GROUND, FsmAction.CLEAR_SEQUENCE)
+        set(AnsiState.CSI_PARAM, ByteClass.UTF8_PAYLOAD, AnsiState.GROUND, FsmAction.CLEAR_SEQUENCE)
+        set(AnsiState.CSI_INTERMEDIATE, ByteClass.UTF8_PAYLOAD, AnsiState.GROUND, FsmAction.CLEAR_SEQUENCE)
+        set(AnsiState.CSI_IGNORE, ByteClass.UTF8_PAYLOAD, AnsiState.GROUND, FsmAction.CLEAR_SEQUENCE)
 
         // CSI_ENTRY
         set(AnsiState.CSI_ENTRY, ByteClass.PARAM_DIGIT, AnsiState.CSI_PARAM, FsmAction.PARAM_DIGIT)
@@ -268,9 +269,7 @@ internal object AnsiStateMachine {
         set(AnsiState.DCS_ENTRY, ByteClass.OSC_INTRO, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
         set(AnsiState.DCS_ENTRY, ByteClass.SOS_PM_APC_INTRO, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
         set(AnsiState.DCS_ENTRY, ByteClass.FINAL_BYTE, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
-        // A malformed UTF-8 byte before the DCS introducer has completed must not be replayed
-        // as a query once later ASCII completes it.  Swallow the remainder through ST/CAN/SUB.
-        set(AnsiState.DCS_ENTRY, ByteClass.UTF8_PAYLOAD, AnsiState.IGNORE_UNTIL_ST, FsmAction.STRING_END)
+        set(AnsiState.DCS_ENTRY, ByteClass.UTF8_PAYLOAD, AnsiState.DCS_PASSTHROUGH, FsmAction.DCS_IGNORE_START)
 
         val s = AnsiState.DCS_PASSTHROUGH
         set(s, ByteClass.INTERMEDIATE, s, FsmAction.DCS_PUT_ASCII)

--- a/ketraterm-parser/src/test/kotlin/io/github/ketraterm/parser/TerminalParserTest.kt
+++ b/ketraterm-parser/src/test/kotlin/io/github/ketraterm/parser/TerminalParserTest.kt
@@ -375,6 +375,77 @@ class TerminalParserTest {
         }
 
         @Test
+        fun `malformed UTF-8 inside active ESC CSI and DCS cannot dispatch the stale command`() {
+            val cases =
+                listOf(
+                    "ESC" to byteArrayOf(0x1B, 0xC3.toByte(), '7'.code.toByte()),
+                    "CSI" to "\u001B[31".encodeToByteArray() + byteArrayOf(0xC3.toByte(), 'm'.code.toByte()),
+                    "DCS" to "\u001BP\$q".encodeToByteArray() + byteArrayOf(0xC3.toByte()) + "m\u001B\\".encodeToByteArray(),
+                )
+
+            for ((name, stream) in cases) {
+                for (split in 1..stream.size) {
+                    val f = TerminalParserFixture()
+                    f.parser.accept(stream, 0, split)
+                    f.parser.accept(stream, split, stream.size - split)
+                    f.endOfInput()
+
+                    assertAll(
+                        { assertEquals(AnsiState.GROUND, f.state.fsmState, "$name split=$split") },
+                        { assertFalse(f.sink.events.contains("saveCursor"), "$name split=$split") },
+                        { assertFalse(f.sink.events.contains("restoreCursor"), "$name split=$split") },
+                        { assertFalse(f.sink.events.contains("setForegroundIndexed:1"), "$name split=$split") },
+                        { assertFalse(f.sink.events.contains("queryStatusString:m"), "$name split=$split") },
+                        {
+                            assertFalse(
+                                f.sink.events.contains(writeCodepoint(0xC3)),
+                                "malformed byte leaked as printable text; $name split=$split",
+                            )
+                        },
+                    )
+                }
+            }
+        }
+
+        @Test
+        fun `malformed UTF-8 within OSC is contained by BEL ST CAN SUB and never leaks printable bytes`() {
+            val terminators =
+                listOf(
+                    "BEL" to "\u0007".encodeToByteArray(),
+                    "ST" to "\u001B\\".encodeToByteArray(),
+                    "CAN" to byteArrayOf(0x18),
+                    "SUB" to byteArrayOf(0x1A),
+                )
+
+            for ((name, terminator) in terminators) {
+                val stream = "\u001B]2;bad".encodeToByteArray() + byteArrayOf(0xC3.toByte()) + terminator
+                for (split in 1..stream.size) {
+                    val f = TerminalParserFixture()
+                    f.parser.accept(stream, 0, split)
+                    f.parser.accept(stream, split, stream.size - split)
+                    f.endOfInput()
+
+                    assertAll(
+                        { assertEquals(AnsiState.GROUND, f.state.fsmState, "$name split=$split") },
+                        {
+                            assertFalse(
+                                f.sink.events.any { it.startsWith("writeCodepoint:") },
+                                "string payload leaked as printable text; $name split=$split",
+                            )
+                        },
+                        {
+                            if (name == "BEL" || name == "ST") {
+                                assertEquals(listOf("setWindowTitle:bad�"), f.sink.events, "$name split=$split")
+                            } else {
+                                assertTrue(f.sink.events.isEmpty(), "$name split=$split")
+                            }
+                        },
+                    )
+                }
+            }
+        }
+
+        @Test
         fun `combining mark variation selector ZWJ and regional indicators form clusters`() {
             val f = TerminalParserFixture()
 

--- a/ketraterm-parser/src/test/kotlin/io/github/ketraterm/parser/ansi/AnsiStateMachineTest.kt
+++ b/ketraterm-parser/src/test/kotlin/io/github/ketraterm/parser/ansi/AnsiStateMachineTest.kt
@@ -201,15 +201,16 @@ class AnsiStateMachineTest {
         asciiAction: Int,
         executeAction: Int,
         utf8Action: Int,
-        endAction: Int,
+        stEndAction: Int,
+        canSubEndAction: Int,
     ) {
         assertClasses(escapeState, stringAsciiPayloadClassesExceptSt, bodyState, asciiAction)
 
         assertAll(
             { assertTransition(escapeState, ByteClass.EXECUTE, bodyState, executeAction) },
             { assertTransition(escapeState, ByteClass.UTF8_PAYLOAD, bodyState, utf8Action) },
-            { assertTransition(escapeState, ByteClass.ST_INTRO, AnsiState.GROUND, endAction) },
-            { assertTransition(escapeState, ByteClass.CAN_SUB, AnsiState.GROUND, endAction) },
+            { assertTransition(escapeState, ByteClass.ST_INTRO, AnsiState.GROUND, stEndAction) },
+            { assertTransition(escapeState, ByteClass.CAN_SUB, AnsiState.GROUND, canSubEndAction) },
             { assertTransition(escapeState, ByteClass.ESC, escapeState, FsmAction.IGNORE) },
             { assertTransition(escapeState, ByteClass.DEL, escapeState, FsmAction.IGNORE) },
         )
@@ -930,7 +931,8 @@ class AnsiStateMachineTest {
                 asciiAction = FsmAction.OSC_PUT_ASCII,
                 executeAction = FsmAction.OSC_EXECUTE_CONTROL,
                 utf8Action = FsmAction.OSC_PUT_UTF8,
-                endAction = FsmAction.OSC_END,
+                stEndAction = FsmAction.OSC_END,
+                canSubEndAction = FsmAction.STRING_END,
             )
         }
 
@@ -942,7 +944,8 @@ class AnsiStateMachineTest {
                 asciiAction = FsmAction.DCS_PUT_ASCII,
                 executeAction = FsmAction.DCS_PUT_ASCII,
                 utf8Action = FsmAction.DCS_PUT_UTF8,
-                endAction = FsmAction.DCS_END,
+                stEndAction = FsmAction.DCS_END,
+                canSubEndAction = FsmAction.STRING_END,
             )
         }
 
@@ -956,7 +959,8 @@ class AnsiStateMachineTest {
                         asciiAction = FsmAction.IGNORE,
                         executeAction = FsmAction.IGNORE,
                         utf8Action = FsmAction.IGNORE,
-                        endAction = FsmAction.STRING_END,
+                        stEndAction = FsmAction.STRING_END,
+                        canSubEndAction = FsmAction.STRING_END,
                     )
                 },
                 {
@@ -966,7 +970,8 @@ class AnsiStateMachineTest {
                         asciiAction = FsmAction.IGNORE,
                         executeAction = FsmAction.IGNORE,
                         utf8Action = FsmAction.IGNORE,
-                        endAction = FsmAction.STRING_END,
+                        stEndAction = FsmAction.STRING_END,
+                        canSubEndAction = FsmAction.STRING_END,
                     )
                 },
             )
@@ -975,10 +980,10 @@ class AnsiStateMachineTest {
         @Test
         fun `CAN and SUB use string-specific termination actions inside string states`() {
             assertAll(
-                { assertTransition(AnsiState.OSC_STRING, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.OSC_END) },
-                { assertTransition(AnsiState.OSC_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.OSC_END) },
-                { assertTransition(AnsiState.DCS_PASSTHROUGH, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.DCS_END) },
-                { assertTransition(AnsiState.DCS_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.DCS_END) },
+                { assertTransition(AnsiState.OSC_STRING, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },
+                { assertTransition(AnsiState.OSC_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },
+                { assertTransition(AnsiState.DCS_PASSTHROUGH, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },
+                { assertTransition(AnsiState.DCS_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },
                 { assertTransition(AnsiState.SOS_PM_APC_STRING, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },
                 { assertTransition(AnsiState.SOS_PM_APC_ESCAPE, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },
                 { assertTransition(AnsiState.IGNORE_UNTIL_ST, ByteClass.CAN_SUB, AnsiState.GROUND, FsmAction.STRING_END) },


### PR DESCRIPTION
…ching stale ANSI/CSI/DCS/OSC commands. Add exhaustive tests and update documentation.